### PR TITLE
#242 Configurable product matchers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.20
 
 require (
 	github.com/dlclark/regexp2 v1.10.0
+	github.com/gobwas/glob v0.2.3
 	github.com/hdm/jarm-go v0.0.7
 	github.com/prometheus/client_golang v1.14.0
 	github.com/sirupsen/logrus v1.9.0

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dlclark/regexp2 v1.10.0 h1:+/GIL799phkJqYW+3YbOd8LCcbHzT0Pbo8zl70MHsq0=
 github.com/dlclark/regexp2 v1.10.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
+github.com/gobwas/glob v0.2.3 h1:A4xDbljILXROh+kObIiy5kIaPYD8e96x1tgBhUI5J+Y=
+github.com/gobwas/glob v0.2.3/go.mod h1:d3Ez4x06l9bZtSvzIay5+Yzi0fmZzPgnTbPcKjJAkT8=
 github.com/gofrs/uuid v3.3.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.5/go.mod h1:6O5/vntMXwX2lRkT1hjjk0nAC1IDOTvTlVgjlRvqsdk=

--- a/lib/nmap/matchers.go
+++ b/lib/nmap/matchers.go
@@ -57,8 +57,11 @@ func (ms Matchers) FilterGlob(patterns ...string) Matchers {
 }
 
 type ExtractResult struct {
-	Info  Info[string] `json:"info"`
-	Regex string       `json:"regex"`
+	Probe     string `json:"probe"`
+	Service   string `json:"service"`
+	Regex     string `json:"regex"`
+	SoftMatch bool   `json:"softmatch"`
+	Info[string]
 }
 
 func (ms Matchers) ExtractInfoFromBytes(input []byte) ([]ExtractResult, error) {
@@ -73,7 +76,12 @@ func (ms Matchers) ExtractInfoFromRunes(input []rune) (result []ExtractResult, e
 		}
 		if r.Found() {
 			result = append(result, ExtractResult{
-				Info: r.Render(m.Info), Regex: m.re.String()})
+				Probe:     m.Probe,
+				Service:   m.Service,
+				Regex:     m.re.String(),
+				SoftMatch: m.Soft,
+				Info:      r.Render(m.Info),
+			})
 		}
 	}
 	return result, nil

--- a/lib/nmap/matchers.go
+++ b/lib/nmap/matchers.go
@@ -1,6 +1,7 @@
 package nmap
 
 import (
+	"errors"
 	"io"
 	"os"
 
@@ -65,11 +66,14 @@ func (ms Matchers) ExtractInfoFromBytes(input []byte) ([]ExtractResult, error) {
 	return ms.ExtractInfoFromRunes(intoRunes(input))
 }
 
-func (ms Matchers) ExtractInfoFromRunes(input []rune) (result []ExtractResult, err error) {
+func (ms Matchers) ExtractInfoFromRunes(input []rune) ([]ExtractResult, error) {
+	var result []ExtractResult
+	var errs []error
 	for _, m := range ms {
 		r := m.MatchRunes(input)
 		if err := r.Err(); err != nil {
-			return nil, err
+			errs = append(errs, err)
+			continue
 		}
 		if r.Found() {
 			result = append(result, ExtractResult{
@@ -81,7 +85,7 @@ func (ms Matchers) ExtractInfoFromRunes(input []rune) (result []ExtractResult, e
 			})
 		}
 	}
-	return result, nil
+	return result, errors.Join(errs...)
 }
 
 var globalMatchers Matchers

--- a/lib/ssh/log.go
+++ b/lib/ssh/log.go
@@ -19,17 +19,17 @@ import "github.com/zmap/zgrab2/lib/nmap"
 // HandshakeLog contains detailed information about each step of the
 // SSH handshake, and can be encoded to JSON.
 type HandshakeLog struct {
-	Banner             string             `json:"banner,omitempty"`
-	ServerID           *EndpointId        `json:"server_id,omitempty"`
-	ClientID           *EndpointId        `json:"client_id,omitempty"`
-	ServerKex          *KexInitMsg        `json:"server_key_exchange,omitempty"`
-	ClientKex          *KexInitMsg        `json:"client_key_exchange,omitempty"`
-	AlgorithmSelection *Algorithms        `json:"algorithm_selection,omitempty"`
-	DHKeyExchange      kexAlgorithm       `json:"key_exchange,omitempty"`
-	UserAuth           []string           `json:"userauth,omitempty"`
-	Crypto             *kexResult         `json:"crypto,omitempty"`
-	RawBanner          string             `json:"banner_raw,omitempty"`
-	Product            *nmap.Info[string] `json:"product,omitempty"`
+	Banner             string               `json:"banner,omitempty"`
+	ServerID           *EndpointId          `json:"server_id,omitempty"`
+	ClientID           *EndpointId          `json:"client_id,omitempty"`
+	ServerKex          *KexInitMsg          `json:"server_key_exchange,omitempty"`
+	ClientKex          *KexInitMsg          `json:"client_key_exchange,omitempty"`
+	AlgorithmSelection *Algorithms          `json:"algorithm_selection,omitempty"`
+	DHKeyExchange      kexAlgorithm         `json:"key_exchange,omitempty"`
+	UserAuth           []string             `json:"userauth,omitempty"`
+	Crypto             *kexResult           `json:"crypto,omitempty"`
+	RawBanner          string               `json:"banner_raw,omitempty"`
+	Products           []nmap.ExtractResult `json:"products,omitempty"`
 }
 
 type EndpointId struct {

--- a/modules/banner/scanner.go
+++ b/modules/banner/scanner.go
@@ -13,7 +13,6 @@ import (
 	"net"
 	"regexp"
 	"strconv"
-	"strings"
 
 	"github.com/zmap/zgrab2"
 	"github.com/zmap/zgrab2/lib/nmap"
@@ -129,8 +128,8 @@ func (scanner *Scanner) Init(flags zgrab2.ScanFlags) error {
 		scanner.probe = []byte(strProbe)
 	}
 
-	patterns := strings.Split(f.ProductMatchers, `,`)
-	scanner.productMatchers = nmap.SelectMatchersGlob(patterns...)
+	scanner.productMatchers = nmap.SelectMatchersGlob(f.ProductMatchers)
+	log.Printf("MATCHERS: %d", len(scanner.productMatchers))
 
 	return nil
 }

--- a/modules/banner/scanner.go
+++ b/modules/banner/scanner.go
@@ -4,6 +4,7 @@
 package banner
 
 import (
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"io"
@@ -12,20 +13,21 @@ import (
 	"net"
 	"regexp"
 	"strconv"
-	"encoding/hex"
 
 	"github.com/zmap/zgrab2"
+	"github.com/zmap/zgrab2/lib/nmap"
 )
 
 // Flags give the command-line flags for the banner module.
 type Flags struct {
 	zgrab2.BaseFlags
-	Probe     string `long:"probe" default:"\\n" description:"Probe to send to the server. Use triple slashes to escape, for example \\\\\\n is literal \\n. Mutually exclusive with --probe-file" `
-	ProbeFile string `long:"probe-file" description:"Read probe from file as byte array (hex). Mutually exclusive with --probe"`
-	Pattern   string `long:"pattern" description:"Pattern to match, must be valid regexp."`
-	UseTLS    bool   `long:"tls" description:"Sends probe with TLS connection. Loads TLS module command options. "`
-	MaxTries  int    `long:"max-tries" default:"1" description:"Number of tries for timeouts and connection errors before giving up. Includes making TLS connection if enabled."`
-	Hex       bool   `long:"hex" description:"Store banner value in hex. "`
+	Probe           string   `long:"probe" default:"\\n" description:"Probe to send to the server. Use triple slashes to escape, for example \\\\\\n is literal \\n. Mutually exclusive with --probe-file" `
+	ProbeFile       string   `long:"probe-file" description:"Read probe from file as byte array (hex). Mutually exclusive with --probe"`
+	Pattern         string   `long:"pattern" description:"Pattern to match, must be valid regexp."`
+	UseTLS          bool     `long:"tls" description:"Sends probe with TLS connection. Loads TLS module command options. "`
+	MaxTries        int      `long:"max-tries" default:"1" description:"Number of tries for timeouts and connection errors before giving up. Includes making TLS connection if enabled."`
+	Hex             bool     `long:"hex" description:"Store banner value in hex. "`
+	ProductMatchers []string `long:"product-matchers" description:"Matchers from nmap-service-probes file used to detect product info. Format: <probe>/<service> (wildcards supported)."`
 	zgrab2.TLSFlags
 }
 
@@ -35,15 +37,17 @@ type Module struct {
 
 // Scanner is the implementation of the zgrab2.Scanner interface.
 type Scanner struct {
-	config *Flags
-	regex  *regexp.Regexp
-	probe  []byte
+	config          *Flags
+	regex           *regexp.Regexp
+	probe           []byte
+	productMatchers nmap.Matchers
 }
 
 // ScanResults instances are returned by the module's Scan function.
 type Results struct {
-	Banner string `json:"banner,omitempty"`
-	Length int    `json:"length,omitempty"`
+	Banner  string             `json:"banner,omitempty"`
+	Length  int                `json:"length,omitempty"`
+	Product *nmap.Info[string] `json:"product,omitempty"`
 }
 
 // RegisterModule is called by modules/banner.go to register the scanner.
@@ -124,6 +128,7 @@ func (scanner *Scanner) Init(flags zgrab2.ScanFlags) error {
 		scanner.probe = []byte(strProbe)
 	}
 
+	scanner.productMatchers = nmap.SelectMatchersGlob(f.ProductMatchers...)
 	return nil
 }
 
@@ -181,16 +186,21 @@ func (scanner *Scanner) Scan(target zgrab2.ScanTarget) (zgrab2.ScanStatus, inter
 	if readerr != io.EOF && readerr != nil {
 		return zgrab2.TryGetScanStatus(readerr), nil, readerr
 	}
-	var results Results
-	if scanner.config.Hex {
-		results = Results{Banner: hex.EncodeToString(ret), Length: len(ret)}
-	} else {
-		results = Results{Banner: string(ret), Length: len(ret)}
+
+	results := Results{
+		Banner: string(ret),
+		Length: len(ret),
 	}
+	if scanner.config.Hex {
+		results.Banner = hex.EncodeToString(ret)
+	}
+
+	if found, product, _ := scanner.productMatchers.MatchBytes(ret); found {
+		results.Product = &product
+	}
+
 	if scanner.regex.Match(ret) {
 		return zgrab2.SCAN_SUCCESS, &results, nil
 	}
-
 	return zgrab2.SCAN_PROTOCOL_ERROR, &results, NoMatchError
-
 }

--- a/modules/banner/scanner.go
+++ b/modules/banner/scanner.go
@@ -13,6 +13,7 @@ import (
 	"net"
 	"regexp"
 	"strconv"
+	"strings"
 
 	"github.com/zmap/zgrab2"
 	"github.com/zmap/zgrab2/lib/nmap"
@@ -21,13 +22,13 @@ import (
 // Flags give the command-line flags for the banner module.
 type Flags struct {
 	zgrab2.BaseFlags
-	Probe           string   `long:"probe" default:"\\n" description:"Probe to send to the server. Use triple slashes to escape, for example \\\\\\n is literal \\n. Mutually exclusive with --probe-file" `
-	ProbeFile       string   `long:"probe-file" description:"Read probe from file as byte array (hex). Mutually exclusive with --probe"`
-	Pattern         string   `long:"pattern" description:"Pattern to match, must be valid regexp."`
-	UseTLS          bool     `long:"tls" description:"Sends probe with TLS connection. Loads TLS module command options. "`
-	MaxTries        int      `long:"max-tries" default:"1" description:"Number of tries for timeouts and connection errors before giving up. Includes making TLS connection if enabled."`
-	Hex             bool     `long:"hex" description:"Store banner value in hex. "`
-	ProductMatchers []string `long:"product-matchers" description:"Matchers from nmap-service-probes file used to detect product info. Format: <probe>/<service> (wildcards supported)."`
+	Probe           string `long:"probe" default:"\\n" description:"Probe to send to the server. Use triple slashes to escape, for example \\\\\\n is literal \\n. Mutually exclusive with --probe-file" `
+	ProbeFile       string `long:"probe-file" description:"Read probe from file as byte array (hex). Mutually exclusive with --probe"`
+	Pattern         string `long:"pattern" description:"Pattern to match, must be valid regexp."`
+	UseTLS          bool   `long:"tls" description:"Sends probe with TLS connection. Loads TLS module command options. "`
+	MaxTries        int    `long:"max-tries" default:"1" description:"Number of tries for timeouts and connection errors before giving up. Includes making TLS connection if enabled."`
+	Hex             bool   `long:"hex" description:"Store banner value in hex. "`
+	ProductMatchers string `long:"product-matchers" description:"Matchers from nmap-service-probes file used to detect product info. Format: <probe>/<service>[,...] (wildcards supported)."`
 	zgrab2.TLSFlags
 }
 
@@ -128,7 +129,9 @@ func (scanner *Scanner) Init(flags zgrab2.ScanFlags) error {
 		scanner.probe = []byte(strProbe)
 	}
 
-	scanner.productMatchers = nmap.SelectMatchersGlob(f.ProductMatchers...)
+	patterns := strings.Split(f.ProductMatchers, `,`)
+	scanner.productMatchers = nmap.SelectMatchersGlob(patterns...)
+
 	return nil
 }
 

--- a/modules/banner/scanner.go
+++ b/modules/banner/scanner.go
@@ -45,9 +45,9 @@ type Scanner struct {
 
 // ScanResults instances are returned by the module's Scan function.
 type Results struct {
-	Banner  string             `json:"banner,omitempty"`
-	Length  int                `json:"length,omitempty"`
-	Product *nmap.Info[string] `json:"product,omitempty"`
+	Banner   string               `json:"banner,omitempty"`
+	Length   int                  `json:"length,omitempty"`
+	Products []nmap.ExtractResult `json:"products,omitempty"`
 }
 
 // RegisterModule is called by modules/banner.go to register the scanner.
@@ -195,9 +195,7 @@ func (scanner *Scanner) Scan(target zgrab2.ScanTarget) (zgrab2.ScanStatus, inter
 		results.Banner = hex.EncodeToString(ret)
 	}
 
-	if found, product, _ := scanner.productMatchers.MatchBytes(ret); found {
-		results.Product = &product
-	}
+	results.Products, _ = scanner.productMatchers.ExtractInfoFromBytes(ret)
 
 	if scanner.regex.Match(ret) {
 		return zgrab2.SCAN_SUCCESS, &results, nil

--- a/modules/banner/scanner.go
+++ b/modules/banner/scanner.go
@@ -129,8 +129,6 @@ func (scanner *Scanner) Init(flags zgrab2.ScanFlags) error {
 	}
 
 	scanner.productMatchers = nmap.SelectMatchersGlob(f.ProductMatchers)
-	log.Printf("MATCHERS: %d", len(scanner.productMatchers))
-
 	return nil
 }
 

--- a/modules/ftp/scanner.go
+++ b/modules/ftp/scanner.go
@@ -126,10 +126,7 @@ func (s *Scanner) Protocol() string {
 func (s *Scanner) Init(flags zgrab2.ScanFlags) error {
 	f, _ := flags.(*Flags)
 	s.config = f
-
-	patterns := strings.Split(f.ProductMatchers, `,`)
-	s.productMatchers = nmap.SelectMatchersGlob(patterns...)
-
+	s.productMatchers = nmap.SelectMatchersGlob(f.ProductMatchers)
 	return nil
 }
 

--- a/modules/ftp/scanner.go
+++ b/modules/ftp/scanner.go
@@ -52,9 +52,10 @@ type Flags struct {
 	zgrab2.BaseFlags
 	zgrab2.TLSFlags
 
-	Verbose     bool `long:"verbose" description:"More verbose logging, include debug fields in the scan results"`
-	FTPAuthTLS  bool `long:"authtls" description:"Collect FTPS certificates in addition to FTP banners"`
-	ImplicitTLS bool `long:"implicit-tls" description:"Attempt to connect via a TLS wrapped connection"`
+	Verbose         bool   `long:"verbose" description:"More verbose logging, include debug fields in the scan results"`
+	FTPAuthTLS      bool   `long:"authtls" description:"Collect FTPS certificates in addition to FTP banners"`
+	ImplicitTLS     bool   `long:"implicit-tls" description:"Attempt to connect via a TLS wrapped connection"`
+	ProductMatchers string `long:"product-matchers" default:"*/ftp" description:"Matchers from nmap-service-probes file used to detect product info. Format: <probe>/<service>[,...] (wildcards supported)."`
 }
 
 // Module implements the zgrab2.Module interface.
@@ -126,9 +127,9 @@ func (s *Scanner) Init(flags zgrab2.ScanFlags) error {
 	f, _ := flags.(*Flags)
 	s.config = f
 
-	s.productMatchers = nmap.SelectMatchers(func(m *nmap.Matcher) bool {
-		return strings.HasPrefix(m.Service, "ftp")
-	})
+	patterns := strings.Split(f.ProductMatchers, `,`)
+	s.productMatchers = nmap.SelectMatchersGlob(patterns...)
+
 	return nil
 }
 

--- a/modules/ftp/scanner.go
+++ b/modules/ftp/scanner.go
@@ -27,7 +27,7 @@ type ScanResults struct {
 	// Banner is the initial data banner sent by the server.
 	Banner string `json:"banner,omitempty"`
 
-	Product *nmap.Info[string] `json:"product,omitempty"`
+	Products []nmap.ExtractResult `json:"products,omitempty"`
 
 	// AuthTLSResp is the response to the AUTH TLS command.
 	// Only present if the FTPAuthTLS flag is set.
@@ -284,9 +284,7 @@ func (s *Scanner) Scan(t zgrab2.ScanTarget) (status zgrab2.ScanStatus, result in
 		return zgrab2.TryGetScanStatus(err), &ftp.results, err
 	}
 
-	if found, product, _ := s.productMatchers.MatchBytes([]byte(ftp.results.Banner)); found {
-		ftp.results.Product = &product
-	}
+	ftp.results.Products, _ = s.productMatchers.ExtractInfoFromBytes([]byte(ftp.results.Banner))
 
 	if s.config.FTPAuthTLS && is200Banner {
 		if err := ftp.GetFTPSCertificates(); err != nil {

--- a/modules/http/scanner.go
+++ b/modules/http/scanner.go
@@ -229,9 +229,7 @@ func (scanner *Scanner) Init(flags zgrab2.ScanFlags) error {
 		log.Panicf("Invalid ComputeDecodedBodyHashAlgorithm choice made it through zflags: %s", scanner.config.ComputeDecodedBodyHashAlgorithm)
 	}
 
-	patterns := strings.Split(fl.ProductMatchers, `,`)
-	scanner.productMatchers = nmap.SelectMatchersGlob(patterns...)
-
+	scanner.productMatchers = nmap.SelectMatchersGlob(fl.ProductMatchers)
 	return nil
 }
 

--- a/modules/http/scanner.go
+++ b/modules/http/scanner.go
@@ -79,6 +79,8 @@ type Flags struct {
 
 	// WithBodyLength enables adding the body_size field to the Response
 	WithBodyLength bool `long:"with-body-size" description:"Enable the body_size attribute, for how many bytes actually read"`
+
+	ProductMatchers string `long:"product-matchers" default:"*/http" description:"Matchers from nmap-service-probes file used to detect product info. Format: <probe>/<service>[,...] (wildcards supported)."`
 }
 
 // A Results object is returned by the HTTP module's Scanner.Scan()
@@ -227,9 +229,9 @@ func (scanner *Scanner) Init(flags zgrab2.ScanFlags) error {
 		log.Panicf("Invalid ComputeDecodedBodyHashAlgorithm choice made it through zflags: %s", scanner.config.ComputeDecodedBodyHashAlgorithm)
 	}
 
-	scanner.productMatchers = nmap.SelectMatchers(func(m *nmap.Matcher) bool {
-		return strings.HasPrefix(m.Service, "http")
-	})
+	patterns := strings.Split(fl.ProductMatchers, `,`)
+	scanner.productMatchers = nmap.SelectMatchersGlob(patterns...)
+
 	return nil
 }
 

--- a/modules/imap/scanner.go
+++ b/modules/imap/scanner.go
@@ -37,7 +37,7 @@ type ScanResults struct {
 	// Banner is the string sent by the server immediately after connecting.
 	Banner string `json:"banner,omitempty"`
 
-	Product *nmap.Info[string] `json:"product,omitempty"`
+	Products []nmap.ExtractResult `json:"products,omitempty"`
 
 	// StartTLS is the server's response to the STARTTLS command, if it is sent.
 	StartTLS string `json:"starttls,omitempty"`
@@ -219,9 +219,7 @@ func (scanner *Scanner) Scan(target zgrab2.ScanTarget) (zgrab2.ScanStatus, inter
 	}
 	result.Banner = banner
 
-	if found, product, _ := scanner.productMatchers.MatchBytes([]byte(banner)); found {
-		result.Product = &product
-	}
+	result.Products, _ = scanner.productMatchers.ExtractInfoFromBytes([]byte(banner))
 
 	if scanner.config.StartTLS {
 		ret, err := conn.SendCommand("a001 STARTTLS")

--- a/modules/imap/scanner.go
+++ b/modules/imap/scanner.go
@@ -124,10 +124,7 @@ func (flags *Flags) Help() string {
 func (scanner *Scanner) Init(flags zgrab2.ScanFlags) error {
 	f, _ := flags.(*Flags)
 	scanner.config = f
-
-	patterns := strings.Split(f.ProductMatchers, `,`)
-	scanner.productMatchers = nmap.SelectMatchersGlob(patterns...)
-
+	scanner.productMatchers = nmap.SelectMatchersGlob(f.ProductMatchers)
 	return nil
 }
 

--- a/modules/imap/scanner.go
+++ b/modules/imap/scanner.go
@@ -66,6 +66,8 @@ type Flags struct {
 
 	// Verbose indicates that there should be more verbose logging.
 	Verbose bool `long:"verbose" description:"More verbose logging, include debug fields in the scan results"`
+
+	ProductMatchers string `long:"product-matchers" default:"*/imap" description:"Matchers from nmap-service-probes file used to detect product info. Format: <probe>/<service>[,...] (wildcards supported)."`
 }
 
 // Module implements the zgrab2.Module interface.
@@ -123,9 +125,9 @@ func (scanner *Scanner) Init(flags zgrab2.ScanFlags) error {
 	f, _ := flags.(*Flags)
 	scanner.config = f
 
-	scanner.productMatchers = nmap.SelectMatchers(func(m *nmap.Matcher) bool {
-		return strings.HasPrefix(m.Service, "imap")
-	})
+	patterns := strings.Split(f.ProductMatchers, `,`)
+	scanner.productMatchers = nmap.SelectMatchersGlob(patterns...)
+
 	return nil
 }
 

--- a/modules/pop3/scanner.go
+++ b/modules/pop3/scanner.go
@@ -138,10 +138,7 @@ func (flags *Flags) Help() string {
 func (scanner *Scanner) Init(flags zgrab2.ScanFlags) error {
 	f, _ := flags.(*Flags)
 	scanner.config = f
-
-	patterns := strings.Split(f.ProductMatchers, `,`)
-	scanner.productMatchers = nmap.SelectMatchersGlob(patterns...)
-
+	scanner.productMatchers = nmap.SelectMatchersGlob(f.ProductMatchers)
 	return nil
 }
 

--- a/modules/pop3/scanner.go
+++ b/modules/pop3/scanner.go
@@ -40,7 +40,7 @@ type ScanResults struct {
 	// Banner is the string sent by the server immediately after connecting.
 	Banner string `json:"banner,omitempty"`
 
-	Product *nmap.Info[string] `json:"product,omitempty"`
+	Products []nmap.ExtractResult `json:"products,omitempty"`
 
 	// NOOP is the server's response to the NOOP command, if one is sent.
 	NOOP string `json:"noop,omitempty"`
@@ -233,9 +233,7 @@ func (scanner *Scanner) Scan(target zgrab2.ScanTarget) (zgrab2.ScanStatus, inter
 	}
 	result.Banner = banner
 
-	if found, product, _ := scanner.productMatchers.MatchBytes([]byte(banner)); found {
-		result.Product = &product
-	}
+	result.Products, _ = scanner.productMatchers.ExtractInfoFromBytes([]byte(banner))
 
 	if scanner.config.SendHELP {
 		ret, err := conn.SendCommand("HELP")

--- a/modules/pop3/scanner.go
+++ b/modules/pop3/scanner.go
@@ -81,6 +81,8 @@ type Flags struct {
 
 	// Verbose indicates that there should be more verbose logging.
 	Verbose bool `long:"verbose" description:"More verbose logging, include debug fields in the scan results"`
+
+	ProductMatchers string `long:"product-matchers" default:"*/pop3" description:"Matchers from nmap-service-probes file used to detect product info. Format: <probe>/<service>[,...] (wildcards supported)."`
 }
 
 // Module implements the zgrab2.Module interface.
@@ -137,9 +139,9 @@ func (scanner *Scanner) Init(flags zgrab2.ScanFlags) error {
 	f, _ := flags.(*Flags)
 	scanner.config = f
 
-	scanner.productMatchers = nmap.SelectMatchers(func(m *nmap.Matcher) bool {
-		return strings.HasPrefix(m.Service, "pop3")
-	})
+	patterns := strings.Split(f.ProductMatchers, `,`)
+	scanner.productMatchers = nmap.SelectMatchersGlob(patterns...)
+
 	return nil
 }
 

--- a/modules/smtp/scanner.go
+++ b/modules/smtp/scanner.go
@@ -101,6 +101,8 @@ type Flags struct {
 
 	// Verbose indicates that there should be more verbose logging.
 	Verbose bool `long:"verbose" description:"More verbose logging, include debug fields in the scan results"`
+
+	ProductMatchers string `long:"product-matchers" default:"*/smtp" description:"Matchers from nmap-service-probes file used to detect product info. Format: <probe>/<service>[,...] (wildcards supported)."`
 }
 
 // Module implements the zgrab2.Module interface.
@@ -168,9 +170,9 @@ func (scanner *Scanner) Init(flags zgrab2.ScanFlags) error {
 	f, _ := flags.(*Flags)
 	scanner.config = f
 
-	scanner.productMatchers = nmap.SelectMatchers(func(m *nmap.Matcher) bool {
-		return strings.HasPrefix(m.Service, "smtp")
-	})
+	patterns := strings.Split(f.ProductMatchers, `,`)
+	scanner.productMatchers = nmap.SelectMatchersGlob(patterns...)
+
 	return nil
 }
 

--- a/modules/smtp/scanner.go
+++ b/modules/smtp/scanner.go
@@ -169,10 +169,7 @@ func (flags *Flags) Help() string {
 func (scanner *Scanner) Init(flags zgrab2.ScanFlags) error {
 	f, _ := flags.(*Flags)
 	scanner.config = f
-
-	patterns := strings.Split(f.ProductMatchers, `,`)
-	scanner.productMatchers = nmap.SelectMatchersGlob(patterns...)
-
+	scanner.productMatchers = nmap.SelectMatchersGlob(f.ProductMatchers)
 	return nil
 }
 

--- a/modules/smtp/scanner.go
+++ b/modules/smtp/scanner.go
@@ -44,7 +44,7 @@ type ScanResults struct {
 	// Banner is the string sent by the server immediately after connecting.
 	Banner string `json:"banner,omitempty"`
 
-	Product *nmap.Info[string] `json:"product,omitempty"`
+	Products []nmap.ExtractResult `json:"products,omitempty"`
 
 	// HELO is the server's response to the HELO command, if one is sent.
 	HELO string `json:"helo,omitempty"`
@@ -280,9 +280,7 @@ func (scanner *Scanner) Scan(target zgrab2.ScanTarget) (zgrab2.ScanStatus, inter
 	}
 	result.Banner = banner
 
-	if found, product, _ := scanner.productMatchers.MatchBytes([]byte(banner)); found {
-		result.Product = &product
-	}
+	result.Products, _ = scanner.productMatchers.ExtractInfoFromBytes([]byte(banner))
 
 	if scanner.config.SendHELO {
 		ret, err := conn.SendCommand(getCommand("HELO", scanner.config.HELODomain))

--- a/modules/ssh.go
+++ b/modules/ssh.go
@@ -23,6 +23,7 @@ type SSHFlags struct {
 	GexPreferredBits  uint   `long:"gex-preferred-bits" description:"The preferred number of bits for the DH GEX prime." default:"2048"`
 	HelloOnly         bool   `long:"hello-only" description:"Limit scan to the initial hello message"`
 	Verbose           bool   `long:"verbose" description:"Output additional information, including SSH client properties from the SSH handshake."`
+	ProductMatchers   string `long:"product-matchers" default:"*/ssh" description:"Matchers from nmap-service-probes file used to detect product info. Format: <probe>/<service>[,...] (wildcards supported)."`
 }
 
 type SSHModule struct {
@@ -70,9 +71,9 @@ func (s *SSHScanner) Init(flags zgrab2.ScanFlags) error {
 	f, _ := flags.(*SSHFlags)
 	s.config = f
 
-	s.productMatchers = nmap.SelectMatchers(func(m *nmap.Matcher) bool {
-		return m.Service == "ssh"
-	})
+	patterns := strings.Split(f.ProductMatchers, `,`)
+	s.productMatchers = nmap.SelectMatchersGlob(patterns...)
+
 	return nil
 }
 

--- a/modules/ssh.go
+++ b/modules/ssh.go
@@ -128,9 +128,8 @@ func (s *SSHScanner) Scan(t zgrab2.ScanTarget) (zgrab2.ScanStatus, interface{}, 
 	// TODO FIXME: Distinguish error types
 	status := zgrab2.TryGetScanStatus(err)
 
-	if found, product, _ := s.productMatchers.MatchBytes([]byte(data.RawBanner)); found {
-		data.Product = &product
-	}
+	data.Products, _ = s.productMatchers.ExtractInfoFromBytes([]byte(data.RawBanner))
+
 	return status, data, err
 }
 

--- a/modules/ssh.go
+++ b/modules/ssh.go
@@ -70,10 +70,7 @@ func (f *SSHFlags) Help() string {
 func (s *SSHScanner) Init(flags zgrab2.ScanFlags) error {
 	f, _ := flags.(*SSHFlags)
 	s.config = f
-
-	patterns := strings.Split(f.ProductMatchers, `,`)
-	s.productMatchers = nmap.SelectMatchersGlob(patterns...)
-
+	s.productMatchers = nmap.SelectMatchersGlob(f.ProductMatchers)
 	return nil
 }
 

--- a/modules/telnet/log.go
+++ b/modules/telnet/log.go
@@ -21,7 +21,7 @@ type TelnetLog struct {
 	// Banner is the telnet banner returned by the server.
 	Banner string `json:"banner,omitempty"`
 
-	Product *nmap.Info[string] `json:"product,omitempty"`
+	Products []nmap.ExtractResult `json:"products,omitempty"`
 
 	// Will is the list of options that the server says that it will use.
 	Will []TelnetOption `json:"will,omitempty"`

--- a/modules/telnet/scanner.go
+++ b/modules/telnet/scanner.go
@@ -12,8 +12,6 @@
 package telnet
 
 import (
-	"strings"
-
 	log "github.com/sirupsen/logrus"
 	"github.com/zmap/zgrab2"
 	"github.com/zmap/zgrab2/lib/nmap"
@@ -78,10 +76,7 @@ func (flags *Flags) Help() string {
 func (scanner *Scanner) Init(flags zgrab2.ScanFlags) error {
 	f, _ := flags.(*Flags)
 	scanner.config = f
-
-	patterns := strings.Split(f.ProductMatchers, `,`)
-	scanner.productMatchers = nmap.SelectMatchersGlob(patterns...)
-
+	scanner.productMatchers = nmap.SelectMatchersGlob(f.ProductMatchers)
 	return nil
 }
 

--- a/modules/telnet/scanner.go
+++ b/modules/telnet/scanner.go
@@ -23,9 +23,10 @@ import (
 // Populated by the framework.
 type Flags struct {
 	zgrab2.BaseFlags
-	MaxReadSize int  `long:"max-read-size" description:"Set the maximum number of bytes to read when grabbing the banner" default:"65536"`
-	Banner      bool `long:"force-banner" description:"Always return banner if it has non-zero bytes"`
-	Verbose     bool `long:"verbose" description:"More verbose logging, include debug fields in the scan results"`
+	MaxReadSize     int    `long:"max-read-size" description:"Set the maximum number of bytes to read when grabbing the banner" default:"65536"`
+	Banner          bool   `long:"force-banner" description:"Always return banner if it has non-zero bytes"`
+	Verbose         bool   `long:"verbose" description:"More verbose logging, include debug fields in the scan results"`
+	ProductMatchers string `long:"product-matchers" default:"*/telnet" description:"Matchers from nmap-service-probes file used to detect product info. Format: <probe>/<service>[,...] (wildcards supported)."`
 }
 
 // Module implements the zgrab2.Module interface.
@@ -78,9 +79,9 @@ func (scanner *Scanner) Init(flags zgrab2.ScanFlags) error {
 	f, _ := flags.(*Flags)
 	scanner.config = f
 
-	scanner.productMatchers = nmap.SelectMatchers(func(m *nmap.Matcher) bool {
-		return strings.HasPrefix(m.Service, "telnet")
-	})
+	patterns := strings.Split(f.ProductMatchers, `,`)
+	scanner.productMatchers = nmap.SelectMatchersGlob(patterns...)
+
 	return nil
 }
 

--- a/modules/telnet/scanner.go
+++ b/modules/telnet/scanner.go
@@ -120,8 +120,7 @@ func (scanner *Scanner) Scan(target zgrab2.ScanTarget) (zgrab2.ScanStatus, inter
 		}
 	}
 
-	if found, product, _ := scanner.productMatchers.MatchBytes([]byte(result.Banner)); found {
-		result.Product = &product
-	}
+	result.Products, _ = scanner.productMatchers.ExtractInfoFromBytes([]byte(result.Banner))
+
 	return zgrab2.SCAN_SUCCESS, result, nil
 }


### PR DESCRIPTION
- Products result is combined from all the matched nmap service rules (not only from the first matched one).
- Products result additionaly contains: a probe name, service name, softmatch flag, regex.
- Set of matchers used to detect product can be configured with `--product-matchers` flag.  Supported modules: `banner`, `http`, `smtp`, `imap`, `pop3`, `ftp`, `telnet`, `ssh`.